### PR TITLE
add is_any? method to role restricted objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ post.is_role_restricted?
 post.is?(:admin)
 => true
 
+post.is_any?(:editor, :superadmin)
+=> true
+
 post.roles
 => [:admin, :superadmin]
 ```

--- a/app/models/concerns/acts_as_role_restricted.rb
+++ b/app/models/concerns/acts_as_role_restricted.rb
@@ -74,6 +74,12 @@ module ActsAsRoleRestricted
     roles.include?(role.try(:to_sym))
   end
 
+  # if user.is_any?(:admin, :editor)
+  # returns true if user has any role given
+  def is_any?(*queried_roles)
+    (queried_roles & roles).present?
+  end
+
   # Are both objects unrestricted, or do any roles overlap?
   def roles_overlap?(obj)
     obj_roles = EffectiveRoles.roles_for(obj)

--- a/spec/models/acts_as_role_restricted_spec.rb
+++ b/spec/models/acts_as_role_restricted_spec.rb
@@ -11,6 +11,32 @@ describe 'Acts As Role Restricted' do
     EffectiveRoles.setup { |config| config.roles = roles }
   end
 
+  describe '#is_any?(roles)' do
+    context 'when subject has one of the roles in question' do
+      let(:post) { Post.new.tap { |post| post.roles = [:member] } }
+
+      it 'is true' do
+        post.is_any?(:admin, :member).should be(true)
+      end
+    end
+
+    context 'when subject does not have any of the roles in question' do
+      let(:post) { Post.new.tap { |post| post.roles = [:member] } }
+
+      it 'is false' do
+        post.is_any?(:admin, :superadmin).should be(false)
+      end
+    end
+
+    context 'when subject does not have any roles' do
+      let(:post) { Post.new }
+
+      it 'is false' do
+        post.is_any?(:member, :admin, :superadmin).should be(false)
+      end
+    end
+  end
+
   describe '#roles_permit?(obj)' do
     describe 'when subject has no roles' do
       let(:post) { Post.new }


### PR DESCRIPTION
Added `#is_any?` that will return true if any role given matches.  Let me know if more documentation or bumping the version is desired.
